### PR TITLE
Fix misspelling in src/index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,1 @@
-console.log("hello, word")
+console.log("hello, world")


### PR DESCRIPTION
Related to #7

Correct the misspelling of "hello, word" to "hello, world" in `src/index.js`

